### PR TITLE
Enable usage of NOTIFY responses for reporting new and removed services.

### DIFF
--- a/Classes/SSDPService.m
+++ b/Classes/SSDPService.m
@@ -30,7 +30,7 @@
     self = [super init];
     if (self) {
         _location = [NSURL URLWithString:[headers objectForKey:@"location"]];
-        _serviceType = [headers objectForKey:@"st"];
+        _serviceType = [headers objectForKey:@"st"] ? [headers objectForKey:@"st"] : [headers objectForKey:@"nt"];
         _uniqueServiceName = [headers objectForKey:@"usn"];
         _server = [headers objectForKey:@"server"];
     }

--- a/Classes/SSDPServiceBrowser.h
+++ b/Classes/SSDPServiceBrowser.h
@@ -27,9 +27,9 @@
 @class SSDPService;
 
 @protocol SSDPServiceBrowserDelegate
-- (void) ssdpBrowser:(SSDPServiceBrowser *)browser didNotStartBrowsingForServices:(NSError *)error;
-- (void) ssdpBrowser:(SSDPServiceBrowser *)browser didFindService:(SSDPService *)service;
-- (void) ssdpBrowser:(SSDPServiceBrowser *)browser didRemoveService:(SSDPService *)service;
+- (void)ssdpBrowser:(SSDPServiceBrowser *)browser didNotStartBrowsingForServices:(NSError *)error;
+- (void)ssdpBrowser:(SSDPServiceBrowser *)browser didFindService:(SSDPService *)service;
+- (void)ssdpBrowser:(SSDPServiceBrowser *)browser didRemoveService:(SSDPService *)service;
 @end
 
 
@@ -39,13 +39,12 @@
 @property(readonly, nonatomic) NSString *networkInterface;
 @property(assign, nonatomic) id<SSDPServiceBrowserDelegate> delegate;
 
-- (id) initWithServiceType:(NSString *)serviceType onInterface:(NSString *)networkInterface;
-- (id) initWithServiceType:(NSString *)serviceType;
+- (id)initWithServiceType:(NSString *)serviceType onInterface:(NSString *)networkInterface;
+- (id)initWithServiceType:(NSString *)serviceType;
 
-- (void) startBrowsingForServices;
-- (void) stopBrowsingForServices;
+- (void)startBrowsingForServices;
+- (void)stopBrowsingForServices;
 
-
-+ (NSDictionary *) availableNetworkInterfaces;
++ (NSDictionary *)availableNetworkInterfaces;
 
 @end


### PR DESCRIPTION
Allow the option to receive multicast SSDP notifications (not just send) by not supplying a network interface to bind the socket to.
Implement [SSDPServiceBrowser _notifyDelegateWithRemovedService] for reporting removed devices.
