### PR TITLE
Add unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: objective-c
+before_install:
+  - brew update
+  - brew outdated xctool || brew upgrade xctool
+  - gem install cocoapods --no-ri --no-rdoc
+podfile: TestTarget/Podfile
+script: xctool -workspace TestTarget/TestTarget.xcworkspace -scheme Test
+  Target -sdk iphonesimulator clean build test

--- a/TestTarget/Podfile
+++ b/TestTarget/Podfile
@@ -1,0 +1,10 @@
+platform :ios, '7.0'
+
+target 'TestTarget' do
+  pod 'CocoaAsyncSocket'
+end
+
+target 'TestTargetTests' do
+  pod 'OCMock', '~> 3.1.2'
+end
+

--- a/TestTarget/TestTarget.xcodeproj/project.pbxproj
+++ b/TestTarget/TestTarget.xcodeproj/project.pbxproj
@@ -1,0 +1,559 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0E8698B31AD0081B0008DF82 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698B21AD0081B0008DF82 /* main.m */; };
+		0E8698B61AD0081B0008DF82 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698B51AD0081B0008DF82 /* AppDelegate.m */; };
+		0E8698B91AD0081B0008DF82 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698B81AD0081B0008DF82 /* ViewController.m */; };
+		0E8698BC1AD0081B0008DF82 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E8698BA1AD0081B0008DF82 /* Main.storyboard */; };
+		0E8698BE1AD0081B0008DF82 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0E8698BD1AD0081B0008DF82 /* Images.xcassets */; };
+		0E8698C11AD0081B0008DF82 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0E8698BF1AD0081B0008DF82 /* LaunchScreen.xib */; };
+		0E8698DD1AD009550008DF82 /* SSDPService.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698D81AD009550008DF82 /* SSDPService.m */; };
+		0E8698DE1AD009550008DF82 /* SSDPServiceBrowser.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698DA1AD009550008DF82 /* SSDPServiceBrowser.m */; };
+		0E8698DF1AD009550008DF82 /* SSDPServiceTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698DC1AD009550008DF82 /* SSDPServiceTypes.m */; };
+		F97F4A6E02E9DCC24C4E37C2 /* libPods-TestTargetTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 99CC447BDCE2686045E6FE17 /* libPods-TestTargetTests.a */; };
+		FEB11E64DEFBE6B097DDF533 /* libPods-TestTarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D9D00FCC5BDA814E8CAB969A /* libPods-TestTarget.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0E8698C71AD0081B0008DF82 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0E8698A51AD0081B0008DF82 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0E8698AC1AD0081B0008DF82;
+			remoteInfo = TestTarget;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0E8698AD1AD0081B0008DF82 /* TestTarget.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestTarget.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0E8698B11AD0081B0008DF82 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0E8698B21AD0081B0008DF82 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		0E8698B41AD0081B0008DF82 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		0E8698B51AD0081B0008DF82 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		0E8698B71AD0081B0008DF82 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		0E8698B81AD0081B0008DF82 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		0E8698BB1AD0081B0008DF82 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		0E8698BD1AD0081B0008DF82 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		0E8698C01AD0081B0008DF82 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		0E8698C61AD0081B0008DF82 /* TestTargetTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestTargetTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0E8698CB1AD0081B0008DF82 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0E8698D71AD009550008DF82 /* SSDPService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSDPService.h; sourceTree = "<group>"; };
+		0E8698D81AD009550008DF82 /* SSDPService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPService.m; sourceTree = "<group>"; };
+		0E8698D91AD009550008DF82 /* SSDPServiceBrowser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSDPServiceBrowser.h; sourceTree = "<group>"; };
+		0E8698DA1AD009550008DF82 /* SSDPServiceBrowser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPServiceBrowser.m; sourceTree = "<group>"; };
+		0E8698DB1AD009550008DF82 /* SSDPServiceTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSDPServiceTypes.h; sourceTree = "<group>"; };
+		0E8698DC1AD009550008DF82 /* SSDPServiceTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPServiceTypes.m; sourceTree = "<group>"; };
+		4DF855545637FACD225D1C7F /* Pods-TestTargetTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTargetTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestTargetTests/Pods-TestTargetTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6513F9D042A4F3651D3219D0 /* Pods-TestTargetTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTargetTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestTargetTests/Pods-TestTargetTests.release.xcconfig"; sourceTree = "<group>"; };
+		7EEF95DD128948FF3A819AAC /* Pods-TestTarget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTarget.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestTarget/Pods-TestTarget.release.xcconfig"; sourceTree = "<group>"; };
+		835F689DF964804BE5E9B007 /* Pods-TestTarget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTarget.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestTarget/Pods-TestTarget.debug.xcconfig"; sourceTree = "<group>"; };
+		99CC447BDCE2686045E6FE17 /* libPods-TestTargetTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestTargetTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D9D00FCC5BDA814E8CAB969A /* libPods-TestTarget.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestTarget.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0E8698AA1AD0081B0008DF82 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FEB11E64DEFBE6B097DDF533 /* libPods-TestTarget.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0E8698C31AD0081B0008DF82 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F97F4A6E02E9DCC24C4E37C2 /* libPods-TestTargetTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0E8698A41AD0081B0008DF82 = {
+			isa = PBXGroup;
+			children = (
+				0E8698AF1AD0081B0008DF82 /* TestTarget */,
+				0E8698C91AD0081B0008DF82 /* TestTargetTests */,
+				0E8698AE1AD0081B0008DF82 /* Products */,
+				9865AC13DA9BA196BD933DDB /* Pods */,
+				8C5EB76AF7B4978FAD879631 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		0E8698AE1AD0081B0008DF82 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0E8698AD1AD0081B0008DF82 /* TestTarget.app */,
+				0E8698C61AD0081B0008DF82 /* TestTargetTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0E8698AF1AD0081B0008DF82 /* TestTarget */ = {
+			isa = PBXGroup;
+			children = (
+				0E8698D61AD009550008DF82 /* Classes */,
+				0E8698B41AD0081B0008DF82 /* AppDelegate.h */,
+				0E8698B51AD0081B0008DF82 /* AppDelegate.m */,
+				0E8698B71AD0081B0008DF82 /* ViewController.h */,
+				0E8698B81AD0081B0008DF82 /* ViewController.m */,
+				0E8698BA1AD0081B0008DF82 /* Main.storyboard */,
+				0E8698BD1AD0081B0008DF82 /* Images.xcassets */,
+				0E8698BF1AD0081B0008DF82 /* LaunchScreen.xib */,
+				0E8698B01AD0081B0008DF82 /* Supporting Files */,
+			);
+			path = TestTarget;
+			sourceTree = "<group>";
+		};
+		0E8698B01AD0081B0008DF82 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				0E8698B11AD0081B0008DF82 /* Info.plist */,
+				0E8698B21AD0081B0008DF82 /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		0E8698C91AD0081B0008DF82 /* TestTargetTests */ = {
+			isa = PBXGroup;
+			children = (
+				0E8698CA1AD0081B0008DF82 /* Supporting Files */,
+			);
+			path = TestTargetTests;
+			sourceTree = "<group>";
+		};
+		0E8698CA1AD0081B0008DF82 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				0E8698CB1AD0081B0008DF82 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		0E8698D61AD009550008DF82 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				0E8698D71AD009550008DF82 /* SSDPService.h */,
+				0E8698D81AD009550008DF82 /* SSDPService.m */,
+				0E8698D91AD009550008DF82 /* SSDPServiceBrowser.h */,
+				0E8698DA1AD009550008DF82 /* SSDPServiceBrowser.m */,
+				0E8698DB1AD009550008DF82 /* SSDPServiceTypes.h */,
+				0E8698DC1AD009550008DF82 /* SSDPServiceTypes.m */,
+			);
+			name = Classes;
+			path = ../../Classes;
+			sourceTree = "<group>";
+		};
+		8C5EB76AF7B4978FAD879631 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D9D00FCC5BDA814E8CAB969A /* libPods-TestTarget.a */,
+				99CC447BDCE2686045E6FE17 /* libPods-TestTargetTests.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9865AC13DA9BA196BD933DDB /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				835F689DF964804BE5E9B007 /* Pods-TestTarget.debug.xcconfig */,
+				7EEF95DD128948FF3A819AAC /* Pods-TestTarget.release.xcconfig */,
+				4DF855545637FACD225D1C7F /* Pods-TestTargetTests.debug.xcconfig */,
+				6513F9D042A4F3651D3219D0 /* Pods-TestTargetTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0E8698AC1AD0081B0008DF82 /* TestTarget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0E8698D01AD0081B0008DF82 /* Build configuration list for PBXNativeTarget "TestTarget" */;
+			buildPhases = (
+				D93464F9EC46F2BDB66622F1 /* Check Pods Manifest.lock */,
+				0E8698A91AD0081B0008DF82 /* Sources */,
+				0E8698AA1AD0081B0008DF82 /* Frameworks */,
+				0E8698AB1AD0081B0008DF82 /* Resources */,
+				A66F352619BC11DACDB5B31C /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TestTarget;
+			productName = TestTarget;
+			productReference = 0E8698AD1AD0081B0008DF82 /* TestTarget.app */;
+			productType = "com.apple.product-type.application";
+		};
+		0E8698C51AD0081B0008DF82 /* TestTargetTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0E8698D31AD0081B0008DF82 /* Build configuration list for PBXNativeTarget "TestTargetTests" */;
+			buildPhases = (
+				1F75ACC5ABAB2E73937BD52A /* Check Pods Manifest.lock */,
+				0E8698C21AD0081B0008DF82 /* Sources */,
+				0E8698C31AD0081B0008DF82 /* Frameworks */,
+				0E8698C41AD0081B0008DF82 /* Resources */,
+				A3FBB4D76BE2FDC513AC2E1E /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0E8698C81AD0081B0008DF82 /* PBXTargetDependency */,
+			);
+			name = TestTargetTests;
+			productName = TestTargetTests;
+			productReference = 0E8698C61AD0081B0008DF82 /* TestTargetTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0E8698A51AD0081B0008DF82 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0620;
+				ORGANIZATIONNAME = "Paul Williamson";
+				TargetAttributes = {
+					0E8698AC1AD0081B0008DF82 = {
+						CreatedOnToolsVersion = 6.2;
+					};
+					0E8698C51AD0081B0008DF82 = {
+						CreatedOnToolsVersion = 6.2;
+						TestTargetID = 0E8698AC1AD0081B0008DF82;
+					};
+				};
+			};
+			buildConfigurationList = 0E8698A81AD0081B0008DF82 /* Build configuration list for PBXProject "TestTarget" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0E8698A41AD0081B0008DF82;
+			productRefGroup = 0E8698AE1AD0081B0008DF82 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0E8698AC1AD0081B0008DF82 /* TestTarget */,
+				0E8698C51AD0081B0008DF82 /* TestTargetTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0E8698AB1AD0081B0008DF82 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0E8698BC1AD0081B0008DF82 /* Main.storyboard in Resources */,
+				0E8698C11AD0081B0008DF82 /* LaunchScreen.xib in Resources */,
+				0E8698BE1AD0081B0008DF82 /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0E8698C41AD0081B0008DF82 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		1F75ACC5ABAB2E73937BD52A /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		A3FBB4D76BE2FDC513AC2E1E /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestTargetTests/Pods-TestTargetTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A66F352619BC11DACDB5B31C /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestTarget/Pods-TestTarget-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D93464F9EC46F2BDB66622F1 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0E8698A91AD0081B0008DF82 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0E8698B91AD0081B0008DF82 /* ViewController.m in Sources */,
+				0E8698DF1AD009550008DF82 /* SSDPServiceTypes.m in Sources */,
+				0E8698B61AD0081B0008DF82 /* AppDelegate.m in Sources */,
+				0E8698DE1AD009550008DF82 /* SSDPServiceBrowser.m in Sources */,
+				0E8698B31AD0081B0008DF82 /* main.m in Sources */,
+				0E8698DD1AD009550008DF82 /* SSDPService.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0E8698C21AD0081B0008DF82 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0E8698C81AD0081B0008DF82 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0E8698AC1AD0081B0008DF82 /* TestTarget */;
+			targetProxy = 0E8698C71AD0081B0008DF82 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		0E8698BA1AD0081B0008DF82 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0E8698BB1AD0081B0008DF82 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		0E8698BF1AD0081B0008DF82 /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0E8698C01AD0081B0008DF82 /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		0E8698CE1AD0081B0008DF82 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0E8698CF1AD0081B0008DF82 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		0E8698D11AD0081B0008DF82 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 835F689DF964804BE5E9B007 /* Pods-TestTarget.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = TestTarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		0E8698D21AD0081B0008DF82 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7EEF95DD128948FF3A819AAC /* Pods-TestTarget.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = TestTarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		0E8698D41AD0081B0008DF82 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4DF855545637FACD225D1C7F /* Pods-TestTargetTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = TestTargetTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestTarget.app/TestTarget";
+			};
+			name = Debug;
+		};
+		0E8698D51AD0081B0008DF82 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6513F9D042A4F3651D3219D0 /* Pods-TestTargetTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = TestTargetTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestTarget.app/TestTarget";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0E8698A81AD0081B0008DF82 /* Build configuration list for PBXProject "TestTarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0E8698CE1AD0081B0008DF82 /* Debug */,
+				0E8698CF1AD0081B0008DF82 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0E8698D01AD0081B0008DF82 /* Build configuration list for PBXNativeTarget "TestTarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0E8698D11AD0081B0008DF82 /* Debug */,
+				0E8698D21AD0081B0008DF82 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0E8698D31AD0081B0008DF82 /* Build configuration list for PBXNativeTarget "TestTargetTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0E8698D41AD0081B0008DF82 /* Debug */,
+				0E8698D51AD0081B0008DF82 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0E8698A51AD0081B0008DF82 /* Project object */;
+}

--- a/TestTarget/TestTarget.xcodeproj/project.pbxproj
+++ b/TestTarget/TestTarget.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0E8698DE1AD009550008DF82 /* SSDPServiceBrowser.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698DA1AD009550008DF82 /* SSDPServiceBrowser.m */; };
 		0E8698DF1AD009550008DF82 /* SSDPServiceTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698DC1AD009550008DF82 /* SSDPServiceTypes.m */; };
 		0E8698E11AD00AAF0008DF82 /* SSDPServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698E01AD00AAF0008DF82 /* SSDPServiceTests.m */; };
+		0E8698E41AD00E7A0008DF82 /* SSDPServiceTypesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698E31AD00E7A0008DF82 /* SSDPServiceTypesTests.m */; };
 		F97F4A6E02E9DCC24C4E37C2 /* libPods-TestTargetTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 99CC447BDCE2686045E6FE17 /* libPods-TestTargetTests.a */; };
 		FEB11E64DEFBE6B097DDF533 /* libPods-TestTarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D9D00FCC5BDA814E8CAB969A /* libPods-TestTarget.a */; };
 /* End PBXBuildFile section */
@@ -52,6 +53,7 @@
 		0E8698DC1AD009550008DF82 /* SSDPServiceTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPServiceTypes.m; sourceTree = "<group>"; };
 		0E8698E01AD00AAF0008DF82 /* SSDPServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPServiceTests.m; sourceTree = "<group>"; };
 		0E8698E21AD00D660008DF82 /* PrefixHeader.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrefixHeader.pch; sourceTree = "<group>"; };
+		0E8698E31AD00E7A0008DF82 /* SSDPServiceTypesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPServiceTypesTests.m; sourceTree = "<group>"; };
 		4DF855545637FACD225D1C7F /* Pods-TestTargetTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTargetTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestTargetTests/Pods-TestTargetTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6513F9D042A4F3651D3219D0 /* Pods-TestTargetTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTargetTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestTargetTests/Pods-TestTargetTests.release.xcconfig"; sourceTree = "<group>"; };
 		7EEF95DD128948FF3A819AAC /* Pods-TestTarget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTarget.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestTarget/Pods-TestTarget.release.xcconfig"; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 			isa = PBXGroup;
 			children = (
 				0E8698E01AD00AAF0008DF82 /* SSDPServiceTests.m */,
+				0E8698E31AD00E7A0008DF82 /* SSDPServiceTypesTests.m */,
 				0E8698CA1AD0081B0008DF82 /* Supporting Files */,
 			);
 			path = TestTargetTests;
@@ -358,6 +361,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0E8698E11AD00AAF0008DF82 /* SSDPServiceTests.m in Sources */,
+				0E8698E41AD00E7A0008DF82 /* SSDPServiceTypesTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TestTarget/TestTarget.xcodeproj/project.pbxproj
+++ b/TestTarget/TestTarget.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		0E8698DF1AD009550008DF82 /* SSDPServiceTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698DC1AD009550008DF82 /* SSDPServiceTypes.m */; };
 		0E8698E11AD00AAF0008DF82 /* SSDPServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698E01AD00AAF0008DF82 /* SSDPServiceTests.m */; };
 		0E8698E41AD00E7A0008DF82 /* SSDPServiceTypesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698E31AD00E7A0008DF82 /* SSDPServiceTypesTests.m */; };
+		0EABF6B31AD018FC00BB06B0 /* SSDPServiceBrowserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EABF6B21AD018FC00BB06B0 /* SSDPServiceBrowserTests.m */; };
+		0EABF6B61AD037B700BB06B0 /* SSDPProtocolTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EABF6B51AD037B700BB06B0 /* SSDPProtocolTestHelper.m */; };
 		F97F4A6E02E9DCC24C4E37C2 /* libPods-TestTargetTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 99CC447BDCE2686045E6FE17 /* libPods-TestTargetTests.a */; };
 		FEB11E64DEFBE6B097DDF533 /* libPods-TestTarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D9D00FCC5BDA814E8CAB969A /* libPods-TestTarget.a */; };
 /* End PBXBuildFile section */
@@ -54,6 +56,9 @@
 		0E8698E01AD00AAF0008DF82 /* SSDPServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPServiceTests.m; sourceTree = "<group>"; };
 		0E8698E21AD00D660008DF82 /* PrefixHeader.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrefixHeader.pch; sourceTree = "<group>"; };
 		0E8698E31AD00E7A0008DF82 /* SSDPServiceTypesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPServiceTypesTests.m; sourceTree = "<group>"; };
+		0EABF6B21AD018FC00BB06B0 /* SSDPServiceBrowserTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPServiceBrowserTests.m; sourceTree = "<group>"; };
+		0EABF6B41AD037B700BB06B0 /* SSDPProtocolTestHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSDPProtocolTestHelper.h; sourceTree = "<group>"; };
+		0EABF6B51AD037B700BB06B0 /* SSDPProtocolTestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPProtocolTestHelper.m; sourceTree = "<group>"; };
 		4DF855545637FACD225D1C7F /* Pods-TestTargetTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTargetTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestTargetTests/Pods-TestTargetTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6513F9D042A4F3651D3219D0 /* Pods-TestTargetTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTargetTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestTargetTests/Pods-TestTargetTests.release.xcconfig"; sourceTree = "<group>"; };
 		7EEF95DD128948FF3A819AAC /* Pods-TestTarget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTarget.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestTarget/Pods-TestTarget.release.xcconfig"; sourceTree = "<group>"; };
@@ -131,6 +136,9 @@
 		0E8698C91AD0081B0008DF82 /* TestTargetTests */ = {
 			isa = PBXGroup;
 			children = (
+				0EABF6B41AD037B700BB06B0 /* SSDPProtocolTestHelper.h */,
+				0EABF6B51AD037B700BB06B0 /* SSDPProtocolTestHelper.m */,
+				0EABF6B21AD018FC00BB06B0 /* SSDPServiceBrowserTests.m */,
 				0E8698E01AD00AAF0008DF82 /* SSDPServiceTests.m */,
 				0E8698E31AD00E7A0008DF82 /* SSDPServiceTypesTests.m */,
 				0E8698CA1AD0081B0008DF82 /* Supporting Files */,
@@ -361,7 +369,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				0E8698E11AD00AAF0008DF82 /* SSDPServiceTests.m in Sources */,
+				0EABF6B31AD018FC00BB06B0 /* SSDPServiceBrowserTests.m in Sources */,
 				0E8698E41AD00E7A0008DF82 /* SSDPServiceTypesTests.m in Sources */,
+				0EABF6B61AD037B700BB06B0 /* SSDPProtocolTestHelper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TestTarget/TestTarget.xcodeproj/project.pbxproj
+++ b/TestTarget/TestTarget.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0E8698DD1AD009550008DF82 /* SSDPService.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698D81AD009550008DF82 /* SSDPService.m */; };
 		0E8698DE1AD009550008DF82 /* SSDPServiceBrowser.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698DA1AD009550008DF82 /* SSDPServiceBrowser.m */; };
 		0E8698DF1AD009550008DF82 /* SSDPServiceTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698DC1AD009550008DF82 /* SSDPServiceTypes.m */; };
+		0E8698E11AD00AAF0008DF82 /* SSDPServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8698E01AD00AAF0008DF82 /* SSDPServiceTests.m */; };
 		F97F4A6E02E9DCC24C4E37C2 /* libPods-TestTargetTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 99CC447BDCE2686045E6FE17 /* libPods-TestTargetTests.a */; };
 		FEB11E64DEFBE6B097DDF533 /* libPods-TestTarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D9D00FCC5BDA814E8CAB969A /* libPods-TestTarget.a */; };
 /* End PBXBuildFile section */
@@ -49,6 +50,8 @@
 		0E8698DA1AD009550008DF82 /* SSDPServiceBrowser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPServiceBrowser.m; sourceTree = "<group>"; };
 		0E8698DB1AD009550008DF82 /* SSDPServiceTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSDPServiceTypes.h; sourceTree = "<group>"; };
 		0E8698DC1AD009550008DF82 /* SSDPServiceTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPServiceTypes.m; sourceTree = "<group>"; };
+		0E8698E01AD00AAF0008DF82 /* SSDPServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSDPServiceTests.m; sourceTree = "<group>"; };
+		0E8698E21AD00D660008DF82 /* PrefixHeader.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrefixHeader.pch; sourceTree = "<group>"; };
 		4DF855545637FACD225D1C7F /* Pods-TestTargetTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTargetTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestTargetTests/Pods-TestTargetTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6513F9D042A4F3651D3219D0 /* Pods-TestTargetTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTargetTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestTargetTests/Pods-TestTargetTests.release.xcconfig"; sourceTree = "<group>"; };
 		7EEF95DD128948FF3A819AAC /* Pods-TestTarget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestTarget.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestTarget/Pods-TestTarget.release.xcconfig"; sourceTree = "<group>"; };
@@ -118,6 +121,7 @@
 			children = (
 				0E8698B11AD0081B0008DF82 /* Info.plist */,
 				0E8698B21AD0081B0008DF82 /* main.m */,
+				0E8698E21AD00D660008DF82 /* PrefixHeader.pch */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -125,6 +129,7 @@
 		0E8698C91AD0081B0008DF82 /* TestTargetTests */ = {
 			isa = PBXGroup;
 			children = (
+				0E8698E01AD00AAF0008DF82 /* SSDPServiceTests.m */,
 				0E8698CA1AD0081B0008DF82 /* Supporting Files */,
 			);
 			path = TestTargetTests;
@@ -352,6 +357,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0E8698E11AD00AAF0008DF82 /* SSDPServiceTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -468,6 +474,7 @@
 			baseConfigurationReference = 835F689DF964804BE5E9B007 /* Pods-TestTarget.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				GCC_PREFIX_HEADER = TestTarget/PrefixHeader.pch;
 				INFOPLIST_FILE = TestTarget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -480,6 +487,7 @@
 			baseConfigurationReference = 7EEF95DD128948FF3A819AAC /* Pods-TestTarget.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				GCC_PREFIX_HEADER = TestTarget/PrefixHeader.pch;
 				INFOPLIST_FILE = TestTarget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/TestTarget/TestTarget.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/TestTarget/TestTarget.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:TestTarget.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/TestTarget/TestTarget.xcodeproj/xcshareddata/xcschemes/TestTarget.xcscheme
+++ b/TestTarget/TestTarget.xcodeproj/xcshareddata/xcschemes/TestTarget.xcscheme
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0620"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0E8698AC1AD0081B0008DF82"
+               BuildableName = "TestTarget.app"
+               BlueprintName = "TestTarget"
+               ReferencedContainer = "container:TestTarget.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0E8698C51AD0081B0008DF82"
+               BuildableName = "TestTargetTests.xctest"
+               BlueprintName = "TestTargetTests"
+               ReferencedContainer = "container:TestTarget.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0E8698C51AD0081B0008DF82"
+               BuildableName = "TestTargetTests.xctest"
+               BlueprintName = "TestTargetTests"
+               ReferencedContainer = "container:TestTarget.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0E8698AC1AD0081B0008DF82"
+            BuildableName = "TestTarget.app"
+            BlueprintName = "TestTarget"
+            ReferencedContainer = "container:TestTarget.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0E8698AC1AD0081B0008DF82"
+            BuildableName = "TestTarget.app"
+            BlueprintName = "TestTarget"
+            ReferencedContainer = "container:TestTarget.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0E8698AC1AD0081B0008DF82"
+            BuildableName = "TestTarget.app"
+            BlueprintName = "TestTarget"
+            ReferencedContainer = "container:TestTarget.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TestTarget/TestTarget.xcworkspace/contents.xcworkspacedata
+++ b/TestTarget/TestTarget.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:TestTarget.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/TestTarget/TestTarget/AppDelegate.h
+++ b/TestTarget/TestTarget/AppDelegate.h
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.h
+//  TestTarget
+//
+//  Created by Paul Williamson on 04/04/2015.
+//  Copyright (c) 2015 Paul Williamson. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/TestTarget/TestTarget/AppDelegate.m
+++ b/TestTarget/TestTarget/AppDelegate.m
@@ -1,0 +1,45 @@
+//
+//  AppDelegate.m
+//  TestTarget
+//
+//  Created by Paul Williamson on 04/04/2015.
+//  Copyright (c) 2015 Paul Williamson. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+@end

--- a/TestTarget/TestTarget/Base.lproj/LaunchScreen.xib
+++ b/TestTarget/TestTarget/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 Paul Williamson. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TestTarget" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/TestTarget/TestTarget/Base.lproj/Main.storyboard
+++ b/TestTarget/TestTarget/Base.lproj/Main.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/TestTarget/TestTarget/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/TestTarget/TestTarget/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/TestTarget/TestTarget/Info.plist
+++ b/TestTarget/TestTarget/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>ssdp.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/TestTarget/TestTarget/PrefixHeader.pch
+++ b/TestTarget/TestTarget/PrefixHeader.pch
@@ -1,0 +1,30 @@
+//
+//  PrefixHeader.pch
+//  Copyright (c) 2015 Paul Williamson
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+// Including prefix header, as the class files do not contain a reference to
+// Foundation.h
+
+#ifdef __OBJC__
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#endif

--- a/TestTarget/TestTarget/ViewController.h
+++ b/TestTarget/TestTarget/ViewController.h
@@ -1,0 +1,15 @@
+//
+//  ViewController.h
+//  TestTarget
+//
+//  Created by Paul Williamson on 04/04/2015.
+//  Copyright (c) 2015 Paul Williamson. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/TestTarget/TestTarget/ViewController.m
+++ b/TestTarget/TestTarget/ViewController.m
@@ -1,0 +1,27 @@
+//
+//  ViewController.m
+//  TestTarget
+//
+//  Created by Paul Williamson on 04/04/2015.
+//  Copyright (c) 2015 Paul Williamson. All rights reserved.
+//
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view, typically from a nib.
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+@end

--- a/TestTarget/TestTarget/main.m
+++ b/TestTarget/TestTarget/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  TestTarget
+//
+//  Created by Paul Williamson on 04/04/2015.
+//  Copyright (c) 2015 Paul Williamson. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/TestTarget/TestTargetTests/Info.plist
+++ b/TestTarget/TestTargetTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>ssdp.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/TestTarget/TestTargetTests/SSDPProtocolTestHelper.h
+++ b/TestTarget/TestTargetTests/SSDPProtocolTestHelper.h
@@ -1,0 +1,33 @@
+//
+//  SSDPServiceBrowserDelegateTestHelper.h
+//  Copyright (c) 2015 Paul Williamson
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+#import "SSDPServiceBrowser.h"
+
+typedef void (^CallbackBlock)(id firstArgument, id secondArgument);
+
+@interface SSDPProtocolTestHelper : NSObject <SSDPServiceBrowserDelegate>
+
+@property (copy, nonatomic) CallbackBlock callbackBlock;
+
+@end

--- a/TestTarget/TestTargetTests/SSDPProtocolTestHelper.m
+++ b/TestTarget/TestTargetTests/SSDPProtocolTestHelper.m
@@ -1,0 +1,49 @@
+//
+//  SSDPServiceBrowserDelegateTestHelper.m
+//  Copyright (c) 2015 Paul Williamson
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "SSDPProtocolTestHelper.h"
+
+@implementation SSDPProtocolTestHelper
+
+- (void)ssdpBrowser:(SSDPServiceBrowser *)browser didFindService:(SSDPService *)service
+{
+    if (self.callbackBlock) {
+        self.callbackBlock(browser, service);
+    }
+}
+
+- (void)ssdpBrowser:(SSDPServiceBrowser *)browser didNotStartBrowsingForServices:(NSError *)error
+{
+    if (self.callbackBlock) {
+        self.callbackBlock(browser, error);
+    }
+}
+
+- (void)ssdpBrowser:(SSDPServiceBrowser *)browser didRemoveService:(SSDPService *)service
+{
+    if (self.callbackBlock) {
+        self.callbackBlock(browser, service);
+    }
+}
+
+@end

--- a/TestTarget/TestTargetTests/SSDPServiceBrowserTests.m
+++ b/TestTarget/TestTargetTests/SSDPServiceBrowserTests.m
@@ -1,0 +1,249 @@
+//
+//  SSDPServiceBrowserTests.m
+//  Copyright (c) 2015 Paul Williamson
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import <CocoaAsyncSocket/GCDAsyncUdpSocket.h>
+#import "SSDPServiceBrowser.h"
+#import "SSDPService.h"
+#import "SSDPProtocolTestHelper.h"
+
+
+// You should normally favour dependancy injection, but as this is legacy code,
+// we have to expose the private property instead.
+@interface SSDPServiceBrowser ()
+@property (strong, nonatomic) GCDAsyncUdpSocket *socket;
+- (NSString *)_userAgentString;
+- (NSString *)_prepareSearchRequest;
+
+// GCDAsyncUDPSocket delegate methods
+- (void)udpSocket:(GCDAsyncUdpSocket *)sock didReceiveData:(NSData *)data fromAddress:(NSData *)address withFilterContext:(id)filterContext;
+- (void)udpSocketDidClose:(GCDAsyncUdpSocket *)sock withError:(NSError *)error;
+@end
+
+
+@interface SSDPServiceBrowserTests : XCTestCase
+@property (strong, nonatomic) id mockSocket;
+@end
+
+
+@implementation SSDPServiceBrowserTests
+
+- (void)setUp
+{
+    [super setUp];
+    _mockSocket = [OCMockObject niceMockForClass:[GCDAsyncUdpSocket class]];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    [_mockSocket stopMocking];
+}
+
+- (void)testInitialisationSetsServiceTypeAndInterface
+{
+    // given
+    NSString *serviceType = @"serviceType";
+    NSString *interface = @"interface";
+    
+    // when
+    SSDPServiceBrowser *browser = [[SSDPServiceBrowser alloc]
+                                   initWithServiceType:serviceType
+                                   onInterface:interface];
+    
+    // then
+    XCTAssertNotNil(browser, @"Browser should not be nil");
+    XCTAssert([browser.serviceType isEqualToString:serviceType],
+              @"Browser should set service type");
+    XCTAssert([browser.networkInterface isEqualToString:interface],
+              @"Browser should set network interface");
+}
+
+- (void)testInitialisationSetsServiceType
+{
+    // given
+    NSString *serviceType = @"serviceType";
+    
+    // when
+    SSDPServiceBrowser *browser = [[SSDPServiceBrowser alloc]
+                                   initWithServiceType:serviceType];
+    
+    // then
+    XCTAssertNotNil(browser, @"Browser should not be nil");
+    XCTAssert([browser.serviceType isEqualToString:serviceType],
+              @"Browser should set service type");
+    XCTAssertNil(browser.networkInterface,
+                 @"Browser should not set network interface");
+}
+
+- (void)testInitialisationHasSaneDefaults
+{
+    // when
+    SSDPServiceBrowser *browser = [[SSDPServiceBrowser alloc] init];
+    
+    // then
+    XCTAssertNotNil(browser, @"Browser should not be nil");
+    XCTAssert([browser.serviceType isEqualToString:@"ssdp:all"],
+              @"Browser should set service type");
+    XCTAssertNil(browser.networkInterface,
+                 @"Browser should not set network interface");
+}
+
+- (void)testStartBrowsingForServicesSendsData
+{
+    SSDPServiceBrowser *browser = [[SSDPServiceBrowser alloc] init];
+    browser.socket = _mockSocket;
+    
+    // Stub methods to return success
+    [[[_mockSocket stub] andReturnValue:@(YES)]
+     bindToAddress:[OCMArg any]
+     error:[OCMArg anyObjectRef]];
+    
+    [[[_mockSocket stub] andReturnValue:@(YES)]
+     joinMulticastGroup:[OCMArg any]
+     error:[OCMArg anyObjectRef]];
+    
+    [[[_mockSocket stub] andReturnValue:@(YES)]
+     beginReceiving:[OCMArg anyObjectRef]];
+    
+    NSString *searchHeader = [NSString stringWithFormat:
+                              @"M-SEARCH * HTTP/1.1\r\n"
+                              @"HOST: 239.255.255.250:1900\r\n"
+                              @"MAN: \"ssdp:discover\"\r\n"
+                              @"ST: ssdp:all\r\n"
+                              @"MX: 3\r\n"
+                              @"USER-AGENT: %@/1\r\n\r\n\r\n",
+                              [browser _userAgentString]];
+    NSData *data = [searchHeader dataUsingEncoding:NSUTF8StringEncoding];
+    
+    // expectation
+    [[_mockSocket expect] sendData:data
+                            toHost:@"239.255.255.250"
+                              port:1900
+                       withTimeout:-1
+                               tag:11];
+    
+    // call
+    [browser startBrowsingForServices];
+    
+    // verify
+    [_mockSocket verify];
+}
+
+- (void)testStoppingBrowsingForServicesClosesSocket
+{
+    SSDPServiceBrowser *browser = [[SSDPServiceBrowser alloc] init];
+    browser.socket = _mockSocket;
+    
+    // expect
+    [[_mockSocket expect] close];
+    
+    // we can't check that the socket is nil due to the lazy instantiation I
+    // added because the class doesn't support dependancy injection
+    
+    // call
+    [browser stopBrowsingForServices];
+    
+    // verify
+    [_mockSocket verify];
+}
+
+- (void)testReceivingDataInformsDelegate
+{
+    SSDPServiceBrowser *browser = [[SSDPServiceBrowser alloc] init];
+    SSDPProtocolTestHelper *protocolHelper = [[SSDPProtocolTestHelper alloc] init];
+    browser.delegate = protocolHelper;
+    NSString *desc = @"recieving data informs delegate";
+    XCTestExpectation *expectation = [self expectationWithDescription:desc];
+    NSDictionary *expected = @{ @"location" : @"exampleLocation",
+                                @"server" : @"exampleServer",
+                                @"cacheControl" : @"exampleCacheControl",
+                                @"searchTarget" : @"exampleSearchTarget",
+                                @"usn" : @"exampleUSN" };
+    
+    // add a callback helper because the callback is sent with GCD
+    protocolHelper.callbackBlock = ^void (SSDPServiceBrowser *argBrowser, SSDPService *service) {
+        
+        // expectations
+        XCTAssert([argBrowser isEqual:browser],
+                  @"Protocol should pass browser instance");
+        
+        NSURL *url = [NSURL URLWithString:expected[@"location"]];
+        XCTAssert([service.location isEqual:url],
+                  @"Protocol should pass service");
+        
+        XCTAssert([service.serviceType isEqualToString:expected[@"searchTarget"]],
+                  @"Protocol should pass service");
+        
+        XCTAssert([service.uniqueServiceName isEqualToString:expected[@"usn"]],
+                  @"Protocol should pass service");
+        
+        XCTAssert([service.server isEqualToString:expected[@"server"]],
+                  @"Protocol should pass service");
+        
+        // inform that test has finished
+        [expectation fulfill];
+    };
+    
+    NSString *header = [NSString stringWithFormat:
+                        @"HTTP/1.1 200 OK\r\n"
+                        @"LOCATION: %@\r\n"
+                        @"SERVER: %@\r\n"
+                        @"CACHE-CONTROL: %@\r\n"
+                        @"EXT: \r\n"
+                        @"ST: %@\r\n"
+                        @"USN: %@\r\n\r\n",
+                        expected[@"location"],
+                        expected[@"server"],
+                        expected[@"cacheControl"],
+                        expected[@"searchTarget"],
+                        expected[@"usn"]];
+    
+    NSData *data = [header dataUsingEncoding:NSUTF8StringEncoding];
+    [browser udpSocket:nil didReceiveData:data fromAddress:nil withFilterContext:nil];
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testSocketClosingInformsDelegateWithError
+{
+    SSDPServiceBrowser *browser = [[SSDPServiceBrowser alloc] init];
+    id fakeError = [OCMockObject mockForClass:[NSError class]];
+    SSDPProtocolTestHelper *protocolHelper = [[SSDPProtocolTestHelper alloc] init];
+    browser.delegate = protocolHelper;
+    NSString *desc = @"informs delegate with error";
+    XCTestExpectation *expectation = [self expectationWithDescription:desc];
+    protocolHelper.callbackBlock = ^void (SSDPServiceBrowser *argBrowser, NSError *error) {
+        
+        XCTAssert([argBrowser isEqual:browser], @"Browser should be passed to delegate");
+        XCTAssert([error isEqual:fakeError], @"Socket error should be passed to delegate");
+        [expectation fulfill];
+    };
+    
+    [browser udpSocketDidClose:nil withError:fakeError];
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    [fakeError stopMocking];
+}
+
+@end

--- a/TestTarget/TestTargetTests/SSDPServiceTests.m
+++ b/TestTarget/TestTargetTests/SSDPServiceTests.m
@@ -1,0 +1,57 @@
+//
+//  SSDPServiceTests.m
+//  Copyright (c) 2015 Paul Williamson
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "SSDPService.h"
+
+static NSString * const kLocationHeaderString = @"headerString";
+static NSString * const kServiceTypeHeaderString = @"serviceType";
+static NSString * const kUniqueServiceNameHeaderString = @"usn";
+static NSString * const kServerHeaderString = @"server";
+
+@interface SSDPServiceTests : XCTestCase
+
+@end
+
+@implementation SSDPServiceTests
+
+- (void)testServiceCanBeInitiatedWithHeaders {
+    // given
+    NSDictionary *headers = @{ @"location" : kLocationHeaderString,
+                               @"st" : kServiceTypeHeaderString,
+                               @"usn" : kUniqueServiceNameHeaderString,
+                               @"server" : kServiceTypeHeaderString };
+    NSURL *location = [NSURL URLWithString:kLocationHeaderString];
+    
+    // when
+    SSDPService *service = [[SSDPService alloc] initWithHeaders:headers];
+    
+    // then
+    XCTAssert([service.location isEqual:location], @"Location should be set");
+    XCTAssert([service.serviceType isEqualToString:kServiceTypeHeaderString], @"Service type should be set");
+    XCTAssert([service.uniqueServiceName isEqualToString:kUniqueServiceNameHeaderString], @"Unique service name should be set");
+    XCTAssert([service.server isEqualToString:kServiceTypeHeaderString], @"Server should be set");
+}
+
+@end

--- a/TestTarget/TestTargetTests/SSDPServiceTypesTests.m
+++ b/TestTarget/TestTargetTests/SSDPServiceTypesTests.m
@@ -1,0 +1,132 @@
+//
+//  SSDPServiceTypesTests.m
+//  Copyright (c) 2015 Paul Williamson
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "SSDPServiceTypes.h"
+
+@interface SSDPServiceTypesTests : XCTestCase
+
+@end
+
+@implementation SSDPServiceTypesTests
+
+#pragma mark - General Device Searches
+
+- (void)testServiceTypeAll {
+    NSString *expected = @"ssdp:all";
+    XCTAssert([SSDPServiceType_All isEqualToString:expected],
+              @"All devices service type incorrect");
+}
+
+- (void)testServiceTypeRootDevice {
+    NSString *expected = @"upnp:rootdevice";
+    XCTAssert([SSDPServiceType_UPnP_RootDevice isEqualToString:expected],
+              @"Root devices service type incorrect");
+}
+
+#pragma mark - Internet Gateway Devices
+
+- (void)testServiceTypeInternetGatewayDevice1 {
+    NSString *expected = @"urn:schemas-upnp-org:device:InternetGatewayDevice:1";
+    XCTAssert([SSDPServiceType_UPnP_InternetGatewayDevice1 isEqualToString:expected],
+              @"Internet gateway device service type incorrect");
+}
+
+- (void)testServiceTypeWANConnectionDevice1 {
+    NSString *expected = @"urn:schemas-upnp-org:device:WANConnectionDevice:1";
+    XCTAssert([SSDPServiceType_UPnP_WANConnectionDevice1 isEqualToString:expected],
+              @"WAN connection device service type incorrect");
+}
+
+- (void)testServiceTypeWANDevice1 {
+    NSString *expected = @"urn:schemas-upnp-org:device:WANDevice:1";
+    XCTAssert([SSDPServiceType_UPnP_WANDevice1 isEqualToString:expected],
+              @"WAN device service type incorrect");
+}
+
+- (void)testServiceTypeWANCommonInterfaceConfig {
+    NSString *expected = @"urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1";
+    XCTAssert([SSDPServiceType_UPnP_WANCommonInterfaceConfig1 isEqualToString:expected],
+              @"WAN common interface config service type incorrect");
+}
+
+- (void)testServiceTypeWANIPConnection {
+    NSString *expected = @"urn:schemas-upnp-org:service:WANIPConnection:1";
+    XCTAssert([SSDPServiceType_UPnP_WANIPConnection1 isEqualToString:expected],
+              @"WAN IP connection service type incorrect");
+}
+
+- (void)testServiceTypeLayer3Forwarding {
+    NSString *expected = @"urn:schemas-upnp-org:service:Layer3Forwarding:1";
+    XCTAssert([SSDPServiceType_UPnP_Layer3Forwarding1 isEqualToString:expected],
+              @"Layer 3 forwarding service type incorrect");
+}
+
+#pragma mark - AV Profile
+
+- (void)testServiceTypeMediaServer {
+    NSString *expected = @"urn:schemas-upnp-org:device:MediaServer:1";
+    XCTAssert([SSDPServiceType_UPnP_MediaServer1 isEqualToString:expected],
+              @"Media server device service type incorrect");
+}
+
+- (void)testServiceTypeMediaRenderer {
+    NSString *expected = @"urn:schemas-upnp-org:device:MediaRenderer:1";
+    XCTAssert([SSDPServiceType_UPnP_MediaRenderer1 isEqualToString:expected],
+              @"Media renderer device service type incorrect");
+}
+
+- (void)testServiceTypeContentDirectory {
+    NSString *expected = @"urn:schemas-upnp-org:service:ContentDirectory:1";
+    XCTAssert([SSDPServiceType_UPnP_ContentDirectory1 isEqualToString:expected],
+              @"Content directory service type incorrect");
+}
+
+- (void)testServiceTypeConnectionManager {
+    NSString *expected = @"urn:schemas-upnp-org:service:ConnectionManager:1";
+    XCTAssert([SSDPServiceType_UPnP_ConnectionManager1 isEqualToString:expected],
+              @"Connection manager service type incorrect");
+}
+
+- (void)testServiceTypeRenderingControl {
+    NSString *expected = @"urn:schemas-upnp-org:service:RenderingControl:1";
+    XCTAssert([SSDPServiceType_UPnP_RenderingControl1 isEqualToString:expected],
+              @"Rendering control service type incorrect");
+}
+
+- (void)testServiceTypeAVTransport {
+    NSString *expected = @"urn:schemas-upnp-org:service:AVTransport:1";
+    XCTAssert([SSDPServiceType_UPnP_AVTransport1 isEqualToString:expected],
+              @"AV transport service type incorrect");
+}
+
+#pragma mark - Microsoft A/V Profile
+
+- (void)testServiceTypeMediaReceiverRegistrar {
+    NSString *expected = @"urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1";
+    XCTAssert([SSDPServiceType_Microsoft_MediaReceiverRegistrar1 isEqualToString:expected],
+              @"Microsoft media receiver registrar service type incorrect");
+}
+
+@end


### PR DESCRIPTION
I've added a Test project and a bunch of unit tests to confirm the behaviour of `CocoaSSDP`. Theres a pretty solid coverage now, just the unhappy path (when socket server gives an error) which isn't really tested.

In order to add the test, I had to make two minor changes to the browser class. The first makes the socket server a property rather than ivar, the second uses lazy instantiation for this property. The rationale for this is so I can inject a mocked socket server to verify behaviour. Neither of these changes affect the API.

I've also added a `.travis.yml` file, which helps with future pull requests. Ping me back here if you want more info.

Cheers!
