### PR TITLE
Fix GCDAsyncUdpSocketDelegate build warning

### DIFF
--- a/Classes/SSDPServiceBrowser.m
+++ b/Classes/SSDPServiceBrowser.m
@@ -50,7 +50,7 @@ typedef enum : NSUInteger {
 } SSDPMessageType;
 
 
-@interface SSDPServiceBrowser ()
+@interface SSDPServiceBrowser <GCDAsyncUdpSocketDelegate> ()
 @property (strong, nonatomic) GCDAsyncUdpSocket *socket;
 @end
 

--- a/Classes/SSDPServiceBrowser.m
+++ b/Classes/SSDPServiceBrowser.m
@@ -50,10 +50,12 @@ typedef enum : NSUInteger {
 } SSDPMessageType;
 
 
-@interface SSDPServiceBrowser <GCDAsyncUdpSocketDelegate> ()
+@interface SSDPServiceBrowser ()
 @property (strong, nonatomic) GCDAsyncUdpSocket *socket;
 @end
 
+@interface SSDPServiceBrowser (Socket) <GCDAsyncUdpSocketDelegate>
+@end
 
 @implementation SSDPServiceBrowser
 


### PR DESCRIPTION
Declaring SSDPServiceBrowser's conformance to <GCDAsyncUdpSocketDelegate> to eliminate the build warning on socket initialization